### PR TITLE
Fix icicle example

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -42,15 +42,25 @@
 
     function getEntity(entityName) {
       return indexedData[entityName];
-      //   return entitiesData.find((d) => d.name === entityName);
     }
 
     function getEntities() {
       return entitiesData.map((d) => d.name);
     }
 
-    function getIndicator(id) {
-      return indicatorLookup[id];
+    function getIndicator(indicatorID) {
+      return indicatorLookup[indicatorID];
+    }
+
+    function getEntityIndicator(entityName, indicatorID){
+      const root = indexedData[entityName][indicatorID] ? false : true;
+      const value = root ?  indexedData[entityName].value : indexedData[entityName][indicatorID];
+      return {
+        root,
+        entityName,
+        value,
+        indicator: indicatorLookup[indicatorID]
+      }
     }
 
     function getIndexMean(indicatorID = 'value', normalised = true) {
@@ -194,6 +204,7 @@
       getEntity,
       getIndicator,
       getEntities,
+      getEntityIndicator,
     };
   }
 

--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -59,7 +59,7 @@
         root,
         entityName,
         value,
-        indicator: indicatorLookup[indicatorID]
+        indicator: root ? {} : indicatorLookup[indicatorID]
       }
     }
 

--- a/examples/icicle.html
+++ b/examples/icicle.html
@@ -7,11 +7,17 @@
     <link rel="stylesheet" href="styles.css">
   </head>
   <body>
+    <main>
     <h1>Icicle</h1>
-    <svg class="chart"></svg>
-    <div class="tooltip">
-
-    </div>
+    <svg class="chart" width="500" height="500">
+    </svg>
+    <p>This examples illustrates how <a href="https://github.com/signal-noise/index-core/">indexCore</a>
+      can be used in conjunction with <a href="https://d3js.org/">D3</a> to draw an Icicle diagram </p>
+      <p>Note that only the structure of the index is visible here, not the values of the selected entity 
+        (London) except for in the tooltip</p>
+        <footer><a href="index.html">Examples index</a></footer>
+    </main>
+    <div class="tooltip"></div>
   </body>
   <script>
   function drawIcicle(core, entityName = 'London'){
@@ -29,7 +35,7 @@
       (summed);
 
     let segmentContainer = d3.select('.chart')
-      .attr("viewBox", [0, 0, width+50, height+50])
+      .attr("viewBox", [0, 0, width, height])
       .attr('width', width)
       .attr('height', height)
       .append('g')
@@ -38,6 +44,7 @@
       .data(layedOut.descendants())
       .join('rect')
         .attr('fill',d=>`rgba(50,50,50,${1/(d.depth+1)})`)
+        // .attr('fill',d=>`url(#fill${d.depth+1})`)
         .attr('stroke','black')
         .attr('x', d=>{
           return d.x0
@@ -69,11 +76,11 @@
     console.log(indicatorData)
     if(!indicatorData.root){
       return `
-      ${indicatorData.entityName} ${indicatorData.indicator.id}
+      ${indicatorData.entityName}, indicator ${indicatorData.indicator.id}
       <br>Value ${Number(indicatorData.value).toFixed(2)} / ${indicatorData.indicator.max ? indicatorData.indicator.max : 100}`;
     }else{
       return `
-        ${indicatorData.entityName} index root
+        ${indicatorData.entityName}, index root
         <br>Value ${Number(indicatorData.value).toFixed(2)}`;
     }
   }

--- a/examples/icicle.html
+++ b/examples/icicle.html
@@ -14,8 +14,9 @@
     </pre>
   </body>
   <script>
-  function drawSunburst(core, entityName = 'London'){
-    let root = d3.hierarchy(core.indexStructure)
+  function drawIcicle(core, entityName = 'London'){
+    let root = d3.hierarchy(core.indexStructure);
+    let summed = root.copy().sum(d => d.absoluteWeightings);
     let width = 500; 
     let height = width;
     let margin = {top:10, bottom:10, left:10, right:10};
@@ -25,17 +26,10 @@
       .size([width, height])
       .round(true)
       .padding(0)
-      (root.sum(d=>{
-        if(d.id === 'root'){
-          return 1
-        }
-        return core.getIndicator(d.id).weighting
-      }));
-
-    console.log('L', layedOut)
+      (summed);
 
     let segmentContainer = d3.select('.chart')
-      .attr("viewBox", [0, 0, width, height])
+      .attr("viewBox", [0, 0, width+50, height+50])
       .attr('width', width)
       .attr('height', height)
       .append('g')
@@ -46,17 +40,19 @@
         .attr('fill',d=>`rgba(255,0,255,${1/(d.depth+1)})`)
         .attr('stroke','black')
         .attr('x', d=>{
-          console.log(d);
           return d.x0
         })
         .attr('y', d=>d.y0)
         .attr('width', d=>d.x1 - d.x0)
         .attr('height', d=>d.y1 - d.y0)
         .on('mouseover',(ev, d)=>{
-          console.log(d.data.id, core.getEntity(entityName));
           d3.select('.output')
             .text(`
-${JSON.stringify(core.getEntityIndicator(entityName, d.data.id),null, ' ')}
+${[d.x0, d.y0]}
+${[d.x1, d.y1]}
+---
+${d.value}
+${JSON.stringify(core.getEntityIndicator(entityName, d.data.id).indicator.weighting,null, ' ')}
             `)
         });
 
@@ -69,12 +65,8 @@ ${JSON.stringify(core.getEntityIndicator(entityName, d.data.id),null, ' ')}
     ])
     .then(([entities, indicators])=>{
       const waterOptimisationIndex = indexCore(indicators, entities);
-      drawSunburst(waterOptimisationIndex)
-    })
-    // .catch(()=>{
-    //   d3.select('#error')
-    //     .text('nope');
-    // })
+      drawIcicle(waterOptimisationIndex)
+    });
     
   </script>
 </html>

--- a/examples/icicle.html
+++ b/examples/icicle.html
@@ -8,14 +8,13 @@
   </head>
   <body>
     <main>
-    <h1>Icicle</h1>
-    <svg class="chart" width="500" height="500">
-    </svg>
-    <p>This examples illustrates how <a href="https://github.com/signal-noise/index-core/">indexCore</a>
-      can be used in conjunction with <a href="https://d3js.org/">D3</a> to draw an Icicle diagram </p>
-      <p>Note that only the structure of the index is visible here, not the values of the selected entity 
-        (London) except for in the tooltip</p>
-        <footer><a href="index.html">Examples index</a></footer>
+      <h1>Icicle</h1>
+      <svg class="chart" width="500" height="500">
+      </svg>
+      <p>This example illustrates how <a href="https://github.com/signal-noise/index-core/">indexCore</a> can be used in conjunction with <a href="https://d3js.org/">D3</a> to draw an Icicle diagram </p>
+      <p>Note that only the structure of the index is visible here, not the values of the selected entity (London) except for in the tooltip</p>
+      <p>Data from the <a href="https://github.com/signal-noise/dupont_wateroptimisation_7754">water optimisation index</a></p>
+      <footer><a href="index.html">Examples index</a></footer>
     </main>
     <div class="tooltip"></div>
   </body>
@@ -73,7 +72,6 @@
   }
 
   function tootltipHTML(indicatorData){
-    console.log(indicatorData)
     if(!indicatorData.root){
       return `
       ${indicatorData.entityName}, indicator ${indicatorData.indicator.id}

--- a/examples/icicle.html
+++ b/examples/icicle.html
@@ -56,8 +56,7 @@
           console.log(d.data.id, core.getEntity(entityName));
           d3.select('.output')
             .text(`
-${JSON.stringify(d.data.id == 'root'? core.getEntity(entityName).value : core.getEntity(entityName)[d.data.id])}
-${JSON.stringify(core.getIndicator(d.data.id),null,' ')}
+${JSON.stringify(core.getEntityIndicator(entityName, d.data.id),null, ' ')}
             `)
         });
 

--- a/examples/icicle.html
+++ b/examples/icicle.html
@@ -1,5 +1,7 @@
 <html>
   <head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+    <meta content="utf-8" http-equiv="encoding">
     <script src="../dist/bundle.js"></script>
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <style>
@@ -16,7 +18,7 @@
   <script>
   function drawIcicle(core, entityName = 'London'){
     let root = d3.hierarchy(core.indexStructure);
-    let summed = root.copy().sum(d => d.absoluteWeightings);
+    let summed = root.copy().sum(d => d.absoluteWeighting);
     let width = 500; 
     let height = width;
     let margin = {top:10, bottom:10, left:10, right:10};

--- a/examples/icicle.html
+++ b/examples/icicle.html
@@ -2,18 +2,16 @@
   <head>
     <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
     <meta content="utf-8" http-equiv="encoding">
-    <script src="../dist/bundle.js"></script>
     <script src="https://d3js.org/d3.v7.min.js"></script>
-    <style>
-
-    </style>
+    <script src="../dist/bundle.js"></script>
+    <link rel="stylesheet" href="styles.css">
   </head>
   <body>
     <h1>Icicle</h1>
     <svg class="chart"></svg>
-    <pre class="output">
+    <div class="tooltip">
 
-    </pre>
+    </div>
   </body>
   <script>
   function drawIcicle(core, entityName = 'London'){
@@ -39,7 +37,7 @@
     segmentContainer.selectAll('rect')
       .data(layedOut.descendants())
       .join('rect')
-        .attr('fill',d=>`rgba(255,0,255,${1/(d.depth+1)})`)
+        .attr('fill',d=>`rgba(50,50,50,${1/(d.depth+1)})`)
         .attr('stroke','black')
         .attr('x', d=>{
           return d.x0
@@ -48,16 +46,36 @@
         .attr('width', d=>d.x1 - d.x0)
         .attr('height', d=>d.y1 - d.y0)
         .on('mouseover',(ev, d)=>{
-          d3.select('.output')
-            .text(`
-${[d.x0, d.y0]}
-${[d.x1, d.y1]}
----
-${d.value}
-${JSON.stringify(core.getEntityIndicator(entityName, d.data.id).indicator.weighting,null, ' ')}
-            `)
+          d3.select('.tooltip')
+            .html(tootltipHTML(core.getEntityIndicator(entityName, d.data.id)))
+            .style('opacity', 1)
+            .style('top', ev.pageY)
+            .style('left', ev.pageX)
+        })
+        .on('mousemove',ev=>{
+          d3.select('.tooltip')
+            .style('top', ev.pageY)
+            .style('left', ev.pageX)
+        })
+        .on('mouseout',ev=>{
+          d3.select('.tooltip')
+            .style('opacity',0)
+            .style('top', ev.pageY)
+            .style('left', ev.pageX)
         });
+  }
 
+  function tootltipHTML(indicatorData){
+    console.log(indicatorData)
+    if(!indicatorData.root){
+      return `
+      ${indicatorData.entityName} ${indicatorData.indicator.id}
+      <br>Value ${Number(indicatorData.value).toFixed(2)} / ${indicatorData.indicator.max ? indicatorData.indicator.max : 100}`;
+    }else{
+      return `
+        ${indicatorData.entityName} index root
+        <br>Value ${Number(indicatorData.value).toFixed(2)}`;
+    }
   }
 
   Promise

--- a/examples/icicle2.html
+++ b/examples/icicle2.html
@@ -1,0 +1,121 @@
+<html>
+  <head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+    <meta content="utf-8" http-equiv="encoding">
+    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../dist/bundle.js"></script>
+    <link rel="stylesheet" href="styles.css">
+  </head>
+  <body>
+    <main>
+    <h1>Icicle 2</h1>
+    <svg class="chart" width="500" height="500">
+    </svg>
+    <p>This examples illustrates how <a href="https://github.com/signal-noise/index-core/">indexCore</a>
+      can be used in conjunction with <a href="https://d3js.org/">D3</a> to draw an Icicle diagram </p>
+      <p>Both the structure and the values of the selected entity 
+        (London) are visualised</p>
+        <footer><a href="index.html">Examples index</a></footer>
+    </main>
+    <div class="tooltip"></div>
+  </body>
+  <script>
+  function drawIcicle(core, entityName = 'London'){
+    let root = d3.hierarchy(core.indexStructure);
+    let summed = root.copy().sum(d => d.absoluteWeighting);
+    let entityData = core.indexedData[entityName];
+    console.log(entityData);
+    let width = 500; 
+    let height = width;
+    let margin = {top:10, bottom:10, left:10, right:10};
+    let radius = width/2 - margin.left;
+
+    let layedOut = d3.partition()
+      .size([width, height])
+      .round(true)
+      .padding(0)
+      (summed);
+
+    let segmentContainer = d3.select('.chart')
+      .attr("viewBox", [0, 0, width, height])
+      .attr('width', width)
+      .attr('height', height)
+      .append('g')
+
+    segmentContainer.selectAll('rect')
+      .data(layedOut.descendants())
+      .join('g')
+        .call(selection=>{
+          selection
+            .append('rect')
+            .attr('fill',d=>`rgba(0,0,0,0.2)`)
+            .attr('stroke','white')
+            .attr('x', d=>{
+              return d.x0
+            })
+            .attr('y', d=>d.y0)
+            .attr('width', d=>d.x1 - d.x0)
+            .attr('height', d=>d.y1 - d.y0)
+          
+          selection
+            .append('rect')
+            .attr('fill',d=>`rgba(0,0,0,1)`)
+            .attr('stroke','none')
+            .attr('x', d=>{
+              return d.x0
+            })
+            .attr('y', d=>d.y0)
+            .attr('width', d=>d.x1 - d.x0)
+            .attr('height', d=>{
+              const indicatorData = core.getEntityIndicator(entityName, d.data.id);
+              const maxValue = indicatorData.indicator.max ? Number(indicatorData.indicator.max) : 100;
+              const scaleFactor = Number(indicatorData.value)/maxValue;
+              return (d.y1 - d.y0)*scaleFactor;
+            })
+
+        })
+        .on('mouseover',(ev, d)=>{
+          d3.select('.tooltip')
+            .html(tootltipHTML(core.getEntityIndicator(entityName, d.data.id)))
+            .style('opacity', 1)
+            .style('top', ev.pageY)
+            .style('left', ev.pageX)
+        })
+        .on('mousemove',ev=>{
+          d3.select('.tooltip')
+            .style('top', ev.pageY)
+            .style('left', ev.pageX)
+        })
+        .on('mouseout',ev=>{
+          d3.select('.tooltip')
+            .style('opacity',0)
+            .style('top', ev.pageY)
+            .style('left', ev.pageX)
+        });
+  }
+
+  function tootltipHTML(indicatorData){
+    console.log(indicatorData)
+    if(!indicatorData.root){
+      return `
+      ${indicatorData.entityName}, indicator ${indicatorData.indicator.id}
+      <br>Value ${Number(indicatorData.value).toFixed(2)} / ${indicatorData.indicator.max ? indicatorData.indicator.max : 100}`;
+    }else{
+      return `
+        ${indicatorData.entityName}, index root
+        <br>Value ${Number(indicatorData.value).toFixed(2)}`;
+    }
+  }
+
+  Promise
+    .all([
+      d3.csv('../data/wateroptimisation/entities.csv'),
+      d3.csv('../data/wateroptimisation/indicators.csv'),
+    ])
+    .then(([entities, indicators])=>{
+      const waterOptimisationIndex = indexCore(indicators, entities);
+      drawIcicle(waterOptimisationIndex)
+    });
+    
+  </script>
+</html>

--- a/examples/icicle2.html
+++ b/examples/icicle2.html
@@ -8,14 +8,13 @@
   </head>
   <body>
     <main>
-    <h1>Icicle 2</h1>
-    <svg class="chart" width="500" height="500">
-    </svg>
-    <p>This examples illustrates how <a href="https://github.com/signal-noise/index-core/">indexCore</a>
-      can be used in conjunction with <a href="https://d3js.org/">D3</a> to draw an Icicle diagram </p>
-      <p>Both the structure and the values of the selected entity 
-        (London) are visualised</p>
-        <footer><a href="index.html">Examples index</a></footer>
+      <h1>Icicle 2</h1>
+      <svg class="chart" width="500" height="500">
+      </svg>
+      <p>This example illustrates how <a href="https://github.com/signal-noise/index-core/">indexCore</a> can be used in conjunction with <a href="https://d3js.org/">D3</a> to draw an Icicle diagram </p>
+      <p>Both the structure and the values of the selected entity (defaults to London) are visualised</p>
+      <p>Data from the <a href="https://github.com/signal-noise/dupont_wateroptimisation_7754">water optimisation index</a></p>
+      <footer><a href="index.html">Examples index</a></footer>
     </main>
     <div class="tooltip"></div>
   </body>
@@ -24,7 +23,6 @@
     let root = d3.hierarchy(core.indexStructure);
     let summed = root.copy().sum(d => d.absoluteWeighting);
     let entityData = core.indexedData[entityName];
-    console.log(entityData);
     let width = 500; 
     let height = width;
     let margin = {top:10, bottom:10, left:10, right:10};
@@ -42,7 +40,7 @@
       .attr('height', height)
       .append('g')
 
-    segmentContainer.selectAll('rect')
+    segmentContainer.selectAll('g')
       .data(layedOut.descendants())
       .join('g')
         .call(selection=>{
@@ -60,7 +58,7 @@
           selection
             .append('rect')
             .attr('fill',d=>`rgba(0,0,0,1)`)
-            .attr('stroke','none')
+            .attr('stroke','white')
             .attr('x', d=>{
               return d.x0
             })
@@ -95,7 +93,6 @@
   }
 
   function tootltipHTML(indicatorData){
-    console.log(indicatorData)
     if(!indicatorData.root){
       return `
       ${indicatorData.entityName}, indicator ${indicatorData.indicator.id}

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,19 @@
+<html>
+  <head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+    <meta content="utf-8" http-equiv="encoding">
+    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../dist/bundle.js"></script>
+    <link rel="stylesheet" href="styles.css">
+  </head>
+  <body style="background-color: black;">
+    <main>
+    <h1>IndexCore Examples</h1>
+    <p>Here we have some examples (currently just the one) of using <a href="">indexCore</a>. Whilst the idea is that the module is library/ framework agnostic the way that it presents data to the world means that it's very easy to plug into <a href="https://d3js.org">D3</a> and D3 based visualisation libraries such as <a href="https://airbnb.io/visx/">visx</a>.</p>
+    <h2>Visualisation</h2>
+    <ul>
+      <li><a href="icicle.html">Icicle</a></li>
+    </ul>
+    </main>
+  </body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -9,12 +9,27 @@
   <body style="background-color: black;">
     <main>
     <h1>IndexCore Examples</h1>
-    <p>Here we have some examples (currently just the one) of using <a href="">indexCore</a>. Whilst the idea is that the module is library/ framework agnostic the way that it presents data to the world means that it's very easy to plug into <a href="https://d3js.org">D3</a> and D3 based visualisation libraries such as <a href="https://airbnb.io/visx/">visx</a>.</p>
-    <h2>Visualisation</h2>
+    <p>Here we have some examples of using <a href="">indexCore</a>. Whilst the idea is that the module is library/ framework agnostic the way that it presents data to the world means that it's very easy to plug into <a href="https://d3js.org">D3</a> and D3 based visualisation libraries such as <a href="https://airbnb.io/visx/">visx</a>.</p>
+    <h2>Visualisation, hierarchy</h2>
     <ul>
       <li><a href="icicle.html">Icicle &mdash; structure</a></li>
       <li><a href="icicle.html">Icicle 2 &mdash; structure &amp; data</a></li>
+      <!-- <li>🔜 Sunburst</li>
+      <li>🔜 Dendrogram</li>
+      <li>🔜 Treemap</li>
+      <li>🔜 Circle packing</li> -->
     </ul>
+    <h2>Visualisation, indicators</h2>
+    <ul>
+      <!-- <li>🔜 Bars</li> -->
+      <li><a href="scatter.html">Scatter</a></li>
+    </ul>
+    <h2>Site generation</h2>
+    <!-- <ul>
+      <li>🔜 Static</li>
+      <li>🔜 NextJS</li>
+      <li>🔜 Express</li>
+    </ul> -->
     </main>
   </body>
 </html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -12,7 +12,8 @@
     <p>Here we have some examples (currently just the one) of using <a href="">indexCore</a>. Whilst the idea is that the module is library/ framework agnostic the way that it presents data to the world means that it's very easy to plug into <a href="https://d3js.org">D3</a> and D3 based visualisation libraries such as <a href="https://airbnb.io/visx/">visx</a>.</p>
     <h2>Visualisation</h2>
     <ul>
-      <li><a href="icicle.html">Icicle</a></li>
+      <li><a href="icicle.html">Icicle &mdash; structure</a></li>
+      <li><a href="icicle.html">Icicle 2 &mdash; structure &amp; data</a></li>
     </ul>
     </main>
   </body>

--- a/examples/scatter.html
+++ b/examples/scatter.html
@@ -1,0 +1,117 @@
+<html>
+  <head>
+    <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
+    <meta content="utf-8" http-equiv="encoding">
+    <script src="https://d3js.org/d3.v7.min.js"></script>
+    <script src="../dist/bundle.js"></script>
+    <link rel="stylesheet" href="styles.css">
+  </head>
+  <body>
+    <main>
+      <h1>Scatter</h1>
+      <svg class="chart" width="500" height="500">
+      </svg>
+      <p>This examples illustrates how <a href="https://github.com/signal-noise/index-core/">indexCore</a> can be used to show data accross diferent entities</p>
+      <p>Data from the <a href="https://github.com/signal-noise/dupont_wateroptimisation_7754">water optimisation index</a></p>
+      <footer><a href="index.html">Examples index</a></footer>
+    </main>
+    <div class="tooltip"></div>
+  </body>
+  <script>
+
+  function drawScatter(core, xIndicator, yIndicator){
+    let width = 500;
+    let height = 500;
+    let margin = { top:50, left:50, bottom:50, right:50 };
+    let plotWidth = width-(margin.left + margin.right);
+    let plotHeight = height-(margin.top + margin.bottom);
+    const chartData = Object.entries(core.indexedData)
+      .map(([entity, scores])=>({
+        xValue:Number(scores[xIndicator]),
+        yValue:Number(scores[yIndicator]),
+        entity
+      }));
+
+    let scaleX = d3.scaleLinear()
+      .domain([0, d3.max(chartData, d=>d.xValue)])
+      .range([0, plotWidth]);
+
+    let scaleY = d3.scaleLinear()
+      .domain([0,d3.max(chartData, d=>d.yValue)])
+      .range([plotHeight, 0]);
+
+    d3.select('.chart')
+      .attr("viewBox", [0, 0, width, height])
+      .attr('width', width)
+      .attr('height', height)
+      .append('g')
+        .attr('class', 'plot')
+        .attr('transform', `translate(${margin.left}, ${margin.top})`)
+      .selectAll('g.point')
+        .data(chartData, d=>d.entity)
+        .join('g')
+          .attr('class','point')
+        .append('circle')
+          .attr('cx', d => scaleX(d.xValue))
+          .attr('cy', d => scaleY(d.yValue))
+          .attr('r', 5)
+        .on('mouseover',(ev, d)=>{
+            d3.select('.tooltip')
+            .html(`${d.entity}: <br>
+            ${d.xValue.toFixed(2)}, ${d.yValue.toFixed(2)}`)
+            .style('opacity', 1)
+            .style('top', ev.pageY)
+            .style('left', ev.pageX)
+        })
+        .on('mousemove',ev=>{
+          d3.select('.tooltip')
+            .style('top', ev.pageY)
+            .style('left', ev.pageX)
+        })
+        .on('mouseout',ev=>{
+          d3.select('.tooltip')
+            .style('opacity',0)
+            .style('top', ev.pageY)
+            .style('left', ev.pageX)
+        });;
+// Axes and labeling...
+    d3.select('.chart')
+      .append('g')
+        .attr('transform',`translate(${margin.left},${margin.top})`)
+        .attr('class','yaxis')
+      .call(d3.axisLeft(scaleY))
+
+    d3.select('.chart')
+      .append('g')
+        .attr('transform',`translate(${margin.left},${margin.top+plotHeight})`)
+        .attr('class','xaxis')
+      .call(d3.axisBottom(scaleX));
+
+    d3.select('.chart')
+      .append('text')
+      .attr('text-anchor','middle')
+      .attr('transform',`translate(${margin.left},${margin.top + plotHeight/2}) rotate(-90)`)
+      .attr('dy',-38)
+      .text(`${core.getIndicator(yIndicator).description} (${yIndicator})`)
+
+    d3.select('.chart')
+      .append('text')
+      .attr('text-anchor','middle')
+      .attr('transform',`translate(${margin.left+plotWidth/2},${height})`)
+      .attr('dy', -3)
+      .text(`${core.getIndicator(xIndicator).description} (${xIndicator})`)
+  }
+    
+
+  Promise
+    .all([
+      d3.csv('../data/wateroptimisation/entities.csv'),
+      d3.csv('../data/wateroptimisation/indicators.csv'),
+    ])
+    .then(([entities, indicators])=>{
+      const waterOptimisationIndex = indexCore(indicators, entities);
+      drawScatter(waterOptimisationIndex, '1.1','1.3')
+    });
+    
+  </script>
+</html>

--- a/examples/styles.css
+++ b/examples/styles.css
@@ -1,0 +1,16 @@
+body{
+  font-family: sans-serif;
+}
+
+.tooltip{
+  background-color: white;
+  box-shadow: 15px 15px 0px 0px #000000;
+  width:200px;
+  padding:5px;
+  position: absolute;
+  top:0;
+  left:0;
+  pointer-events: none;
+  transition-property: opacity;
+  transition-duration: 0.1s;
+}

--- a/examples/styles.css
+++ b/examples/styles.css
@@ -1,5 +1,38 @@
 body{
   font-family: sans-serif;
+  background-color: black;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  image-rendering: optimizeSpeed;             /* STOP SMOOTHING, GIVE ME SPEED  */
+  image-rendering: -moz-crisp-edges;          /* Firefox                        */
+  image-rendering: -o-crisp-edges;            /* Opera                          */
+  image-rendering: -webkit-optimize-contrast; /* Chrome (and eventually Safari) */
+  image-rendering: pixelated; /* Chrome */
+  image-rendering: optimize-contrast;         /* CSS3 Proposed                  */
+  -ms-interpolation-mode: nearest-neighbor;   /* IE8+                           */
+
+}
+svg {
+  shape-rendering:crispEdges;
+}
+main{
+  display: inline-block;
+  padding:10px;
+  background-color: rgba(255,255,255,1);
+  background: linear-gradient(90deg, rgb(219, 219, 219) 0%, rgba(255,255,255,1) 8%, rgba(255,255,255,1) 100%);
+  border-radius: 2px;
+}
+p{
+  max-width:500px;
+  margin-top:30px;
+  line-height: 1.5rem;
+}
+a{
+  font-weight: bold;
+  text-decoration: none;
+  color: black;
+  border-bottom: 1px solid black;
 }
 
 .tooltip{
@@ -13,4 +46,8 @@ body{
   pointer-events: none;
   transition-property: opacity;
   transition-duration: 0.1s;
+  opacity:0;
+}
+footer{
+  text-align: right;
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint src/*.js",
     "lint:fix": "eslint src/*.js --fix",
     "build": "rollup --config",
-    "examples": "sirv"
+    "examples": "sirv --dev"
   },
   "author": "",
   "license": "ISC",

--- a/src/index-core.js
+++ b/src/index-core.js
@@ -30,7 +30,7 @@ function indexCore(indicatorsData = [], entitiesData = [], indexMax = 100) {
       root,
       entityName,
       value,
-      indicator: indicatorLookup[indicatorID]
+      indicator: root ? {} : indicatorLookup[indicatorID]
     }
   }
 

--- a/src/index-core.js
+++ b/src/index-core.js
@@ -13,15 +13,25 @@ function indexCore(indicatorsData = [], entitiesData = [], indexMax = 100) {
 
   function getEntity(entityName) {
     return indexedData[entityName];
-    //   return entitiesData.find((d) => d.name === entityName);
   }
 
   function getEntities() {
     return entitiesData.map((d) => d.name);
   }
 
-  function getIndicator(id) {
-    return indicatorLookup[id];
+  function getIndicator(indicatorID) {
+    return indicatorLookup[indicatorID];
+  }
+
+  function getEntityIndicator(entityName, indicatorID){
+    const root = indexedData[entityName][indicatorID] ? false : true;
+    const value = root ?  indexedData[entityName].value : indexedData[entityName][indicatorID];
+    return {
+      root,
+      entityName,
+      value,
+      indicator: indicatorLookup[indicatorID]
+    }
   }
 
   function getIndexMean(indicatorID = 'value', normalised = true) {
@@ -165,6 +175,7 @@ function indexCore(indicatorsData = [], entitiesData = [], indexMax = 100) {
     getEntity,
     getIndicator,
     getEntities,
+    getEntityIndicator,
   };
 }
 

--- a/src/index-core.js
+++ b/src/index-core.js
@@ -112,7 +112,7 @@ function indexCore(indicatorsData = [], entitiesData = [], indexMax = 100) {
     return indexEntity(Object.assign(clone(e), e.user));
   }
 
-  function createStructure(indicatorIds) {
+  function createStructure(indicatorIds, max=indexMax) {
     const tree = { id: 'root', children: [] };
 
     indicatorIds.forEach((id) => {
@@ -132,13 +132,26 @@ function indexCore(indicatorsData = [], entitiesData = [], indexMax = 100) {
           };
           current.children.push(next);
         }
-
         current = next;
       });
     });
+
+    // add absolute weights to the leaf nodes of the hierarchy structure
+    function assignAbsoluteWeightings(node, parentWeight){
+      if(node.children.length===0){
+        node.absoluteWeighting = parentWeight;
+      }else{
+        node.children.forEach(child=>
+          assignAbsoluteWeightings(child, parentWeight * getIndicator(child.id).weighting)
+        );
+      }
+      return node;
+    }
+    assignAbsoluteWeightings(tree, max);
     return tree;
   }
 
+  
   function calculateIndex(exclude = () => false) {
     const onlyIdIndicators = indicatorsData.filter((i) => i.id.match(indicatorIdTest));
     // get a list of the values we need to calculate
@@ -149,7 +162,6 @@ function indexCore(indicatorsData = [], entitiesData = [], indexMax = 100) {
       .sort((i1, i2) => (i2.split('.').length - i1.split('.').length));
 
     indexStructure = createStructure(onlyIdIndicators.map((i) => i.id));
-
     entitiesData.forEach((entity) => {
       const indexedEntity = indexEntity(entity, calculationList);
       indexedEntity.data = entity;


### PR DESCRIPTION
This ended up being a bit more than expected.

Added a convenience method to the indexCore API `getEntityIndicator` this allows you to get all the information about the indicator for a given entity i.e. you get the value of indicator **1.2** for entity  **london** but you now also get all the metadata about that indicator where appropriate; it's weighting, max value, description etc. etc.

Added an 'absoluteWeighting' property to all the leaf nodes of the `indexStructure`. An absolute weighting is the weight of a given node from the point of view of the index as a whole. An example: 
1.1.1 is a leaf node with a weighting of 0.5, 
1.1 has a weighting of 0.3, 
and 1 has a weighting of 0.25, 
The maximum index value is 100 so 
1.1.1 has an absolute weighting of 100 * 0.25 * 0.3 * 0.5 = 3.75
These absolute weightings of leaf nodes can be summed using d3's heirachy.sum() method to determine the weightings of all the parent nodes of the structure for use in visualisations.

e.g.
<img width="474" alt="Screenshot 2021-10-20 at 19 47 04" src="https://user-images.githubusercontent.com/125399/138153253-fea699ac-4944-4c92-a9cf-fb90a0569e63.png">

To run the example `npm run examples` then go to [http://localhost:5000/examples/icicle.html](http://localhost:5000/examples/icicle.html)