### PR TITLE
Remove date object

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ __indicators__ is an array of indicator objects.
   type:["calculated"|"discrete"|"continuous"]
   max:Number,
   min:Number,
-  invert:Bool
+  invert:Bool,
+  diverging:Bool
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@signal-noise/index-core",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "",
   "main": "src/index-core.js",
   "type": "module",

--- a/src/index-core.js
+++ b/src/index-core.js
@@ -175,7 +175,6 @@ function indexCore(indicatorsData = [], entitiesData = [], indexMax = 100) {
     entitiesData.forEach((entity) => {
       const indexedEntity = indexEntity(entity, calculationList);
       indexedEntity.data = entity;
-      indexedEntity.ts = new Date();
       indexedData[entity.name] = indexedEntity;
     });
   }


### PR DESCRIPTION
I added a date object to entities for testing purposes and forgot to remove it thus making it non-serialisable, a problem for using it with static generation in next