### PR TITLE
Fix adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ __allowOverwrite__, optional. By default this is set to true ensuring that all c
 
 
 ### indexCore.__adjustValue(_entityName:String_, _indicatorID:String_, _value:Number_)__
-A function that allows the user to adjust an entity's indicator score within the index the index is recalculated using the new value. The index is recalculated after calling this function.
+A function that allows the user to adjust an entity's (_entityName_) indicator (_indicatorID_) score to a specified _value_. Calculated values for that entity are re-calculated using the new value. If the function is called without _value_ the indicator is reset to it's inital value. If the function is called without _indicatorId_ or _value_ all indicators on the entity are reset to their initial values.
 
 _NOTE: whislt the old value is retained there's currently no way to reset it._
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/index-core",
-  "version": "1.5.0",
+  "version": "1.4.1",
   "description": "",
   "main": "src/index-core.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/index-core",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "",
   "main": "src/index-core.js",
   "type": "module",

--- a/src/index-core.js
+++ b/src/index-core.js
@@ -126,8 +126,11 @@ function indexCore(indicatorsData = [], entitiesData = [], indexMax = 100, allow
     const e = getEntity(entityName);
 
     if(!indicatorID && !value || !e.user){
-        e.user = {};
+        e.user = {};  // no value or indicator specified, reset
+    }else if(!value && e.user){
+      delete e.user[indicatorID]; // no value specified, reset the indicator
     }
+    
 
     if (indicatorLookup[indicatorID] && indicatorLookup[indicatorID].type === 'calculated') {
       console.warn(`${indicatorID} is a calculated value and can not be adjusted directly, perhaps you meant to adjust the weighting?`);

--- a/src/index-core.js
+++ b/src/index-core.js
@@ -124,19 +124,24 @@ function indexCore(indicatorsData = [], entitiesData = [], indexMax = 100, allow
 
   function adjustValue(entityName, indicatorID, value) {
     const e = getEntity(entityName);
-    if (indicatorLookup[indicatorID].type === 'calculated') {
+
+    if(!indicatorID && !value || !e.user){
+        e.user = {};
+    }
+
+    if (indicatorLookup[indicatorID] && indicatorLookup[indicatorID].type === 'calculated') {
       console.warn(`${indicatorID} is a calculated value and can not be adjusted directly, perhaps you meant to adjust the weighting?`);
       return clone(e);
     }
-    if (!e.user) e.user = {};
-    e.user[indicatorID] = value;
+    if(indicatorID !== undefined && value !== undefined){
+      e.user[indicatorID] = value;
+    }
 
     const onlyIdIndicators = getIndexableIndicators(indicatorsData);
     const calculationList = getCalculationList(onlyIdIndicators);
     
-    //note the re-indexed value for the entity is not stored
-    //only the adjustment the re-indexed value is returned to the caller
-    return indexEntity(Object.assign(clone(e), e.user), calculationList, true);
+    indexedData[e.name] = indexEntity(clone(e), calculationList, true);
+    return indexedData[e.name];
   }
 
   function createStructure(indicatorIds) {

--- a/src/index-core.js
+++ b/src/index-core.js
@@ -143,7 +143,7 @@ function indexCore(indicatorsData = [], entitiesData = [], indexMax = 100, allow
     const onlyIdIndicators = getIndexableIndicators(indicatorsData);
     const calculationList = getCalculationList(onlyIdIndicators);
     
-    indexedData[e.name] = indexEntity(clone(e), calculationList, true);
+    indexedData[e.name] = indexEntity(e, calculationList, true);
     return indexedData[e.name];
   }
 

--- a/src/index-core.js
+++ b/src/index-core.js
@@ -132,7 +132,7 @@ function indexCore(indicatorsData = [], entitiesData = [], indexMax = 100, allow
     e.user[indicatorID] = value;
     //note the re-indexed value for the entity is not stored
     //only the adjustment the re-indexed value is returned to the caller
-    return indexEntity(Object.assign(clone(e), e.user));
+    return indexEntity(Object.assign(clone(e), e.user), );
   }
 
   function createStructure(indicatorIds) {
@@ -162,19 +162,27 @@ function indexCore(indicatorsData = [], entitiesData = [], indexMax = 100, allow
     return tree;
   }
 
-  function calculateIndex(overwrite = allowOverwrite) {
-    const onlyIdIndicators = indicatorsData
+  function getCalculationList(indicators){
+    return indicators
+      .filter((i) => (i.type === 'calculated' && !excludeIndicator(i)))
+      .map((i) => i.id)
+      .sort((i1, i2) => (i2.split('.').length - i1.split('.').length));
+  }
+
+  function getIndexableIndicators(indicators){
+    return indicatorsData
       .filter((i) =>{
         const isIndicator = String(i.id).match(indicatorIdTest)
         const isExcluded = excludeIndicator(i);
         return isIndicator && !isExcluded;
       });
+  }
+
+  function calculateIndex(overwrite = allowOverwrite) {
+    const onlyIdIndicators = getIndexableIndicators(indicatorsData);
     // get a list of the values we need to calculate
-    // in order of deepest in the heirachy to to shallowist
-    const calculationList = onlyIdIndicators
-      .filter((i) => (i.type === 'calculated' && !excludeIndicator(i)))
-      .map((i) => i.id)
-      .sort((i1, i2) => (i2.split('.').length - i1.split('.').length));
+    // in order of deepest in the heirachy to the shallowist
+    const calculationList = getCalculationList(onlyIdIndicators);
 
     indexStructure = createStructure(onlyIdIndicators.map((i) => i.id));
 

--- a/src/index-core.js
+++ b/src/index-core.js
@@ -130,9 +130,13 @@ function indexCore(indicatorsData = [], entitiesData = [], indexMax = 100, allow
     }
     if (!e.user) e.user = {};
     e.user[indicatorID] = value;
+
+    const onlyIdIndicators = getIndexableIndicators(indicatorsData);
+    const calculationList = getCalculationList(onlyIdIndicators);
+    
     //note the re-indexed value for the entity is not stored
     //only the adjustment the re-indexed value is returned to the caller
-    return indexEntity(Object.assign(clone(e), e.user), );
+    return indexEntity(Object.assign(clone(e), e.user), calculationList, true);
   }
 
   function createStructure(indicatorIds) {
@@ -179,9 +183,9 @@ function indexCore(indicatorsData = [], entitiesData = [], indexMax = 100, allow
   }
 
   function calculateIndex(overwrite = allowOverwrite) {
-    const onlyIdIndicators = getIndexableIndicators(indicatorsData);
     // get a list of the values we need to calculate
     // in order of deepest in the heirachy to the shallowist
+    const onlyIdIndicators = getIndexableIndicators(indicatorsData);
     const calculationList = getCalculationList(onlyIdIndicators);
 
     indexStructure = createStructure(onlyIdIndicators.map((i) => i.id));
@@ -197,7 +201,7 @@ function indexCore(indicatorsData = [], entitiesData = [], indexMax = 100, allow
     // TODO: make the index recalculating take into account what
     //    has changed in the data rather than doing the whole shebang
     indicatorLookup[indicatorID].userWeighting = weight;
-    calculateIndex();
+    calculateIndex(true);
   }
 
   function filterIndicators(exclude = ()=>false, overwrite=allowOverwrite){

--- a/test/index-core.test.js
+++ b/test/index-core.test.js
@@ -31,6 +31,15 @@ test('adjust indicator', ()=>{
   expect(originalValue).toBe(resetValue);
 })
 
+test('reset individual indicator', ()=>{
+  const simpleIndex = indexCore(simpleIndicators, simpleEntities);
+  simpleIndex.adjustValue('Monopoly','1.1',10);
+  simpleIndex.adjustValue('Monopoly','1.2',1);
+  simpleIndex.adjustValue('Monopoly','1.2');
+  const resetValue = simpleIndex.indexedData['Monopoly'].value;
+  expect(resetValue.toFixed(3)).toBe('53.118')
+})
+
 test('getIndicatorMean index-core', ()=>{
   const waterOptimisationIndex = indexCore(waterIndicators, waterEntities);
   expect(waterOptimisationIndex.getIndexMean('1').toFixed(1)).toBe('72.2');

--- a/test/index-core.test.js
+++ b/test/index-core.test.js
@@ -19,6 +19,18 @@ test('create index-core', ()=>{
   expect(waterOptimisationIndex.indexedData['Naples'].value.toFixed(1)).toBe('76.2');
 });
 
+test('adjust indicator', ()=>{
+  const simpleIndex = indexCore(simpleIndicators, simpleEntities);
+  const originalValue = simpleIndex.indexedData['Monopoly'].value;
+  simpleIndex.adjustValue('Monopoly','1.1',10);
+  const adjustedValue = simpleIndex.indexedData['Monopoly'].value;
+  simpleIndex.adjustValue('Monopoly');
+  const resetValue = simpleIndex.indexedData['Monopoly'].value;
+  expect(originalValue.toFixed(3)).toBe('49.118')
+  expect(adjustedValue.toFixed(3)).toBe('53.118')
+  expect(originalValue).toBe(resetValue);
+})
+
 test('getIndicatorMean index-core', ()=>{
   const waterOptimisationIndex = indexCore(waterIndicators, waterEntities);
   expect(waterOptimisationIndex.getIndexMean('1').toFixed(1)).toBe('72.2');


### PR DESCRIPTION
The __adjustValue__ function wasn't working. 
This PR...
Fixes the __adjustValue__ function, providing the required list of indicators to consider in the calculation.
Adds the ability to reset indicator values either individually or en masse.
Adds tests so it doesn't break again.
Bumps the package version and updates the docs.