### PR TITLE
Add getEntityIndicator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,5 @@ out.txt
 favicon.ico
 data/education/entities.csv
 data/education/index.csv
+data/inclusiveinternet/2021/entities.csv
+data/inclusiveinternet/2021/indicators.csv

--- a/README.md
+++ b/README.md
@@ -94,8 +94,10 @@ You can clear the exclusion by calling the same function with no arguments
 indexCore.filterIndicators()
 ```
 
-### indexCore.__getEntity([indicatorId:String])__:Object
+### indexCore.__getEntity([entityName:String])__:Object
 
+### indexCore.__getEntityIndicator([entityName:String], [indicatorId])__:Object
+This function returns the value of a given indicator (__indicatorId__) for a given entity (__entityName__) if a user set version of the indicator exists, it is that which will be returned.
 ### indexCore.__getEntities()__:Array
 
 ### indexCore.__getIndexMean([indicatorId:String], _[normalise:Boolean=false]_)__:Number

--- a/index.js
+++ b/index.js
@@ -10,39 +10,37 @@ const waterEntities = csvParse(fs.readFileSync(`${waterRootDir}/entities.csv`, '
 
 // const waterOptimisationIndex = indexCore(waterIndicators, waterEntities);
 
-const inclusiveIternetRootDir = 'data/inclusiveinternet';
+const inclusiveIternetRootDir = 'data/inclusiveinternet/2021';
 
 const inclusiveInternetIndicators = csvParse(fs.readFileSync(`${inclusiveIternetRootDir}/indicators.csv`, 'utf-8'));
 const inclusiveInternetEntities = csvParse(fs.readFileSync(`${inclusiveIternetRootDir}/entities.csv`, 'utf-8'));
-
 const inclusiveInternetIndex = indexCore(inclusiveInternetIndicators, inclusiveInternetEntities);
 
 
-const simpleRootDir = 'data/simple-index-set';
+console.log('value', inclusiveInternetIndex.indexedData['Singapore']['value'])
+console.log('1', inclusiveInternetIndex.indexedData['Singapore']['1'])
+console.log('1.2', inclusiveInternetIndex.indexedData['Singapore']['1.2'])
+console.log('1.2.1', inclusiveInternetIndex.getEntityIndicator('Singapore','1.2.1'))
 
-const simpleIndicators = csvParse(fs.readFileSync(`${simpleRootDir}/indicators.csv`, 'utf-8'));
-const simpleEntities = csvParse(fs.readFileSync(`${simpleRootDir}/entities.csv`, 'utf-8'));
+inclusiveInternetIndex.adjustValue('Singapore','1.2.1',50);
 
-const simpleIndex = indexCore(simpleIndicators, simpleEntities);
+console.log('adjusted')
+console.log('value', inclusiveInternetIndex.indexedData['Singapore']['value'])
+console.log('1', inclusiveInternetIndex.indexedData['Singapore']['1'])
+console.log('1.2', inclusiveInternetIndex.indexedData['Singapore']['1.2'])
+console.log('1.2.1', inclusiveInternetIndex.getEntityIndicator('Singapore','1.2.1'))
 
-console.log(simpleIndex.indexedData)
+// const simpleRootDir = 'data/simple-index-set';
 
-// console.log(waterOptimisationIndex.indexedData['Abu Dhabi']['1']);
-// console.log(waterOptimisationIndex.indexedData['Abu Dhabi'].value);
-// console.log(waterOptimisationIndex.indexStructure);
-// console.log(waterOptimisationIndex.getIndexMean('1.1'))
-// console.log(waterOptimisationIndex.getIndexMean('2.1.1'))
-// console.log(waterOptimisationIndex.getIndexMean())
+// const simpleIndicators = csvParse(fs.readFileSync(`${simpleRootDir}/indicators.csv`, 'utf-8'));
+// const simpleEntities = csvParse(fs.readFileSync(`${simpleRootDir}/entities.csv`, 'utf-8'));
 
-// indicator 3.4.4 in the water index has .a and .b sub indicators 
-// for this indicator abu dhabi has different values for a and b
-// const before = JSON.stringify(waterOptimisationIndex.getEntity('Abu Dhabi'), null, ' ')
-// delete before.data;
-// waterOptimisationIndex.filterIndicators(indicator=>{
-//   return String(indicator.id).indexOf('b')>0; // if the indicator includes "b" in it's id ignore it
-// })
-// const after = JSON.stringify(waterOptimisationIndex.getEntity('Abu Dhabi'), null, ' ')
-// delete after.data; // just for neater output (note data is the original data for an entity used to calculate the index)
-
-// console.log('BEFORE', before);
-// console.log('AFTER', after);
+// const simpleIndex = indexCore(simpleIndicators, simpleEntities);
+// console.log(simpleIndex.indexedData['Monopoly'].value)
+// console.log(simpleIndex.indexedData['Monopoly']['1'])
+// console.log(simpleIndex.indexedData['Monopoly']['1.1'])
+// simpleIndex.adjustValue('Monopoly','1.1',10);
+// console.log('---');
+// console.log(simpleIndex.indexedData['Monopoly'].value)
+// console.log(simpleIndex.indexedData['Monopoly']['1'])
+// console.log(simpleIndex.indexedData['Monopoly']['1.1'])

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "@signal-noise/index-core",
-  "version": "1.3.0",
+  "name": "@economist/index-core",
+  "version": "1.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@signal-noise/index-core",
-      "version": "1.3.0",
-      "license": "ISC",
+      "name": "@economist/index-core",
+      "version": "1.4.2",
+      "license": "UNLICENSED",
       "devDependencies": {
         "d3": "^7.0.1",
         "eslint": "^7.32.0",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,16 @@
 {
   "name": "@economist/index-core",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "",
   "main": "src/index-core.js",
   "type": "module",
   "homepage": "https://github.com/signal-noise/index-core",
   "engines": {
     "node": ">=14"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/signal-noise/index-core.git"
   },
   "scripts": {
     "test": "NODE_OPTIONS=--experimental-vm-modules npx jest",
@@ -16,7 +20,7 @@
     "examples": "sirv"
   },
   "author": "tompearson@signalnoise.io",
-  "license": "ISC",
+  "license": "UNLICENSED",
   "devDependencies": {
     "d3": "^7.0.1",
     "eslint": "^7.32.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/index-core",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "description": "",
   "main": "src/index-core.js",
   "type": "module",

--- a/src/index-core.js
+++ b/src/index-core.js
@@ -16,6 +16,13 @@ function indexCore(indicatorsData = [], entitiesData = [], indexMax = 100, allow
     return indexedData[entityName];
   }
 
+  function getEntityIndicator(entityName, indicatorID){
+    if(indexedData[entityName].user && indexedData[entityName].user[indicatorID]){
+      return indexedData[entityName].user[indicatorID];
+    }
+    return indexedData[entityName][indicatorID];
+  }
+
   function getEntities() {
     return entitiesData.map((d) => d.name);
   }
@@ -94,6 +101,7 @@ function indexCore(indicatorsData = [], entitiesData = [], indexMax = 100, allow
 
   function indexEntity(entity, calculationList, overwrite = allowOverwrite) {
     const newEntity = clone(entity);
+    console.log(entity.name,calculationList);
     calculationList.forEach((indicatorID) => {
       if (newEntity[indicatorID] && overwrite === true 
         || !newEntity[indicatorID]) 
@@ -119,8 +127,12 @@ function indexCore(indicatorsData = [], entitiesData = [], indexMax = 100, allow
       .map((indicator) => formatIndicator(indicator, newEntity, indexMax));
 
     newEntity.value = calculateWeightedMean(pillarIndicators, indexMax);
+    if(!newEntity.user){
+      newEntity.user = {};
+    }
     return newEntity;
   }
+
 
   function adjustValue(entityName, indicatorID, value) {
     const e = getEntity(entityName);
@@ -223,8 +235,9 @@ function indexCore(indicatorsData = [], entitiesData = [], indexMax = 100, allow
     adjustValue,
     adjustWeight,
     filterIndicators,
-    getEntity,
     getEntities,
+    getEntity,
+    getEntityIndicator,
     getIndexMean,
     getIndicator,
     getIndicatorLookup,

--- a/src/index-core.js
+++ b/src/index-core.js
@@ -101,7 +101,6 @@ function indexCore(indicatorsData = [], entitiesData = [], indexMax = 100, allow
 
   function indexEntity(entity, calculationList, overwrite = allowOverwrite) {
     const newEntity = clone(entity);
-    console.log(entity.name,calculationList);
     calculationList.forEach((indicatorID) => {
       if (newEntity[indicatorID] && overwrite === true 
         || !newEntity[indicatorID]) 

--- a/test/index-core.test.js
+++ b/test/index-core.test.js
@@ -79,3 +79,9 @@ test('indicator overide index-core', ()=>{
   expect(simpleIndex.indexedData['Catan']['1']).toBe(10);
   expect(simpleIndex.indexedData['Twilight Imperium']['2.3']).toBe(70);
 })
+
+test('get the user set value for an indicator', ()=>{
+  const simpleIndex = indexCore(simpleIndicators, simpleEntities);
+  simpleIndex.adjustValue('Monopoly', '1.2', 3.142);
+  expect(simpleIndex.getEntityIndicator('Monopoly','1.2')).toBe(3.142);
+})


### PR DESCRIPTION
`getEntityIndicator` is a convenience method that returns the current indicator value for a given entity by default this is the user set or calculated value, if a user set value doesn't exist it is the initial value
This is useful as it prevents the user from having to check whether a user set version of the indicator exists when accessing it...
eg.
```js
const indexer = indexCore(indicators, entities)
const initialValue = indexer.getEntityIndicator('Japan', '1.2.3');
// initialValue will be whatever is calculated from or hard coded in the initial entities data
indexer.adjustValue('Japan', '1.2.3', 3.142)
const tweakedValue = indexer.getEntityIndicator('Japan', '1.2.3');
// tweakedValue will be 3.142 
// whilst indexer.getEntity('Japan')['1.2.3'] would still be the same as initialValue
```

As this is a change/ addition to the API I've bumped the version to 1.5.0

There is a test