### PR TITLE
Adjusted value return

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ __allowOverwrite__, optional. By default this is set to true ensuring that all c
 
 
 ### indexCore.__adjustValue(_entityName:String_, _indicatorID:String_, _value:Number_)__
-A function that allows the user to adjust an entity's (_entityName_) indicator (_indicatorID_) score to a specified _value_. Calculated values for that entity are re-calculated using the new value. If the function is called without _value_ the indicator is reset to it's inital value. If the function is called without _indicatorId_ or _value_ all indicators on the entity are reset to their initial values.
+A function that allows the user to adjust an entity's (_entityName_) indicator (_indicatorID_) score to a specified _value_. Calculated values for that entity are re-calculated using the new value. If the function is called without _value_ the indicator is reset to it's inital value. If the function is called without _indicatorId_ or _value_ all indicators on the entity are reset to their initial values. As a convenience the function returns an object with all the recalculated values.
 
 _NOTE: whislt the old value is retained there's currently no way to reset it._
 

--- a/index.js
+++ b/index.js
@@ -17,18 +17,18 @@ const inclusiveInternetEntities = csvParse(fs.readFileSync(`${inclusiveIternetRo
 const inclusiveInternetIndex = indexCore(inclusiveInternetIndicators, inclusiveInternetEntities);
 
 
-console.log('value', inclusiveInternetIndex.indexedData['Singapore']['value'])
-console.log('1', inclusiveInternetIndex.indexedData['Singapore']['1'])
-console.log('1.2', inclusiveInternetIndex.indexedData['Singapore']['1.2'])
-console.log('1.2.1', inclusiveInternetIndex.getEntityIndicator('Singapore','1.2.1'))
+// console.log('value', inclusiveInternetIndex.indexedData['Singapore']['value'])
+// console.log('1', inclusiveInternetIndex.indexedData['Singapore']['1'])
+// console.log('1.2', inclusiveInternetIndex.indexedData['Singapore']['1.2'])
+// console.log('1.2.1', inclusiveInternetIndex.getEntityIndicator('Singapore','1.2.1'))
 
-inclusiveInternetIndex.adjustValue('Singapore','1.2.1',50);
+console.log(inclusiveInternetIndex.adjustValue('Singapore','1.2.1',50));
 
-console.log('adjusted')
-console.log('value', inclusiveInternetIndex.indexedData['Singapore']['value'])
-console.log('1', inclusiveInternetIndex.indexedData['Singapore']['1'])
-console.log('1.2', inclusiveInternetIndex.indexedData['Singapore']['1.2'])
-console.log('1.2.1', inclusiveInternetIndex.getEntityIndicator('Singapore','1.2.1'))
+// console.log('adjusted')
+// console.log('value', inclusiveInternetIndex.indexedData['Singapore']['value'])
+// console.log('1', inclusiveInternetIndex.indexedData['Singapore']['1'])
+// console.log('1.2', inclusiveInternetIndex.indexedData['Singapore']['1.2'])
+// console.log('1.2.1', inclusiveInternetIndex.getEntityIndicator('Singapore','1.2.1'))
 
 // const simpleRootDir = 'data/simple-index-set';
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/index-core",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "",
   "main": "src/index-core.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@economist/index-core",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "",
   "main": "src/index-core.js",
   "type": "module",

--- a/src/index-core.js
+++ b/src/index-core.js
@@ -155,7 +155,11 @@ function indexCore(indicatorsData = [], entitiesData = [], indexMax = 100, allow
     const calculationList = getCalculationList(onlyIdIndicators);
     
     indexedData[e.name] = indexEntity(e, calculationList, true);
-    return indexedData[e.name];
+    // console.log(indexedData[e.name])
+    const adjustedEntity = Object.assign(clone(indexedData[e.name]),indexedData[e.name].user)
+    delete adjustedEntity.user;  
+    delete adjustedEntity.data;  
+    return adjustedEntity;
   }
 
   function createStructure(indicatorIds) {

--- a/test/index-core.test.js
+++ b/test/index-core.test.js
@@ -85,3 +85,11 @@ test('get the user set value for an indicator', ()=>{
   simpleIndex.adjustValue('Monopoly', '1.2', 3.142);
   expect(simpleIndex.getEntityIndicator('Monopoly','1.2')).toBe(3.142);
 })
+
+test('check the return value from adjustValue', ()=>{
+  const simpleIndex = indexCore(simpleIndicators, simpleEntities);
+  const adjustedObject = simpleIndex.adjustValue('Monopoly', '1.2', 3.142);
+  expect(adjustedObject['1.2']).toBe(3.142);
+  expect(adjustedObject['user']).toBe(undefined);
+  expect(adjustedObject['data']).toBe(undefined);
+})


### PR DESCRIPTION
`adjustValue` function now returns a full lookup of all indicator values in their altered state. Also, removes `user` and `data` properties which represent user changes and the original data separately from the calculated values (a representation that's useful for stuff happening inside the module but perhaps not that useful for end users)