### PR TITLE
EIUNAB-3645/Impact : Work with Teams to get the YAML into Backstage.io for all projects

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,9 +5,9 @@
     title: index-core
     namespace: economist-impact
     annotations: 
-      github.com/project-slug: signal-noise/covid-relative-risk/
+      github.com/project-slug: signal-noise/index-core
       # the circleCI project, mirrors github repo in this case: 
-    circleci.com/project-slug: github/signal-noise/covid-relative-risk
+    circleci.com/project-slug: github/signal-noise/index-core
       # GUID - see https://docs.newrelic.com/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard/
     newrelic.com/dashboard-guid: MzY1MjgxOXxWSVp8REFTSEJPQVJEfGRhOjE3MDkwOA
     newrelic.com/dashboard-guid: MzY1MjgxOXxWSVp8REFTSEJPQVJEfGRhOjE5NTIyNw

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,7 @@
+- apiVersion: backstage.io/v1beta1
+  kind: System
+  metadata:
+    name: index-core
+    title: index-core
+    namespace: economist-impact
+    description: index-core for SignalNoise Economist Impact Project

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -4,4 +4,14 @@
     name: index-core
     title: index-core
     namespace: economist-impact
+    annotations: 
+      github.com/project-slug: signal-noise/covid-relative-risk/
+      # the circleCI project, mirrors github repo in this case: 
+    circleci.com/project-slug: github/signal-noise/covid-relative-risk
+      # GUID - see https://docs.newrelic.com/docs/query-your-data/explore-query-data/dashboards/manage-your-dashboard/
+    newrelic.com/dashboard-guid: MzY1MjgxOXxWSVp8REFTSEJPQVJEfGRhOjE3MDkwOA
+    newrelic.com/dashboard-guid: MzY1MjgxOXxWSVp8REFTSEJPQVJEfGRhOjE5NTIyNw
+    description: covid-relative-risk for SignalNoise Economist Impact Project
+    opsgenie:
+      domain: https://economist.app.opsgenie.com/teams/dashboard/49177ca8-5e59-4364-af23-c22cc60c026f/main
     description: index-core for SignalNoise Economist Impact Project


### PR DESCRIPTION
Description
Add to Backstage - Economist Impact Signal Noise Team

Reason for change
Backstage.io rollout across the Economist Group via platform.economist.com

Breaking changes
None

Remarks
Github added, CircleCI Added (where CICD applicable), New Relic added (generic Impact dashboards pending proprietary project and workflow observability), Opsgenie added (where applicable), docs file added to be updated in depth by the team upon review.

Testing
Once merged the Enablement team will test integration into backstage. The yaml files are pulled via polling on the main branch for automated incorporation.

Checklist
My commits, pull request name follow the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
style
I have made corresponding changes to the documentation
I have updated unit tests, integration tests
I have tested in dev environment
I have update swagger, where applicable
I have provided cdk diff result for infrastructure changes, where applicable